### PR TITLE
Make head and tail calls more memory efficient

### DIFF
--- a/src/array.php
+++ b/src/array.php
@@ -27,7 +27,7 @@ function grab(array $source, $keys)
  */
 function head(array $list)
 {
-    return array_shift($list);
+    return $list ? current(array_slice($list, 0, 1)) : null;
 }
 
 /**
@@ -39,5 +39,5 @@ function head(array $list)
  */
 function tail(array $list)
 {
-    return array_pop($list);
+    return $list ? current(array_slice($list, -1, 1)) : null;
 }


### PR DESCRIPTION
Used array_slice instead of array_pop/array_shift to keep a copy of the source array from being created
