### PR TITLE
Add to_array() function

### DIFF
--- a/src/array.php
+++ b/src/array.php
@@ -41,3 +41,21 @@ function tail(array $list)
 {
     return array_pop($list);
 }
+
+/**
+ * Get an array from a value.
+ *
+ * If the value is not an array, it is assumed to be a Traversable.
+ *
+ * @param Traversable|array $value
+ *
+ * @return array
+ */
+function to_array($value)
+{
+    if (is_array($value)) {
+        return $value;
+    }
+
+    return iterator_to_array($value);
+}

--- a/tests/ArrayTest.php
+++ b/tests/ArrayTest.php
@@ -2,6 +2,7 @@
 
 namespace Equip\Assist;
 
+use ArrayObject;
 use Equip;
 use PHPUnit_Framework_TestCase as TestCase;
 
@@ -68,5 +69,28 @@ class ArrayTest extends TestCase
 
         // Works with collections
         $this->assertSame(['c'], Equip\tail($this->list));
+    }
+
+    public function dataArrays()
+    {
+        return [
+            [ [] ],
+            [ ['b'] ],
+            [ ['b' => 'baz'] ],
+        ];
+    }
+
+    /**
+     * @dataProvider dataArrays
+     */
+    public function testToArray($value)
+    {
+        // Works with arrays
+        $this->assertSame($value, Equip\to_array($value));
+
+        $traversable = new ArrayObject($value);
+
+        // And with traversables
+        $this->assertSame($value, Equip\to_array($traversable));
     }
 }


### PR DESCRIPTION
Useful for ensuring that a given value is an array and not an
array-like object.
