### PR TITLE
Add index_by() function

### DIFF
--- a/src/array.php
+++ b/src/array.php
@@ -120,3 +120,27 @@ function tail($list)
     $list = to_array($list);
     return array_pop($list);
 }
+
+/**
+ * Index an collection by a key.
+ *
+ * Rows in the collection can be arrays or objects.
+ *
+ * @param array|Traversable $source
+ *
+ * @return array
+ */
+function index_by($source, $key)
+{
+    $indexed = [];
+
+    foreach ($source as $row) {
+        if (is_object($row)) {
+            $indexed[$row->$key] = $row;
+        } else {
+            $indexed[$row[$key]] = $row;
+        }
+    }
+
+    return $indexed;
+}

--- a/tests/ArrayTest.php
+++ b/tests/ArrayTest.php
@@ -145,4 +145,38 @@ class ArrayTest extends TestCase
         $this->assertSame([3], to_array(3));
         $this->assertSame(['str'], to_array('str'));
     }
+
+    public function testIndexBy()
+    {
+        $collection = [
+            [
+                'id' => 1,
+                'name' => 'joe',
+            ],
+            [
+                'id' => 2,
+                'name' => 'joe',
+            ],
+            [
+                'id' => 3,
+                'name' => 'sue',
+            ],
+        ];
+
+        $indexed = index_by($collection, 'id');
+
+        foreach ($indexed as $key => $row) {
+            $this->assertSame($key, $row['id']);
+        }
+
+        $collection = array_map(function ($row) {
+            return (object) $row;
+        }, $collection);
+
+        $indexed = index_by($collection, 'id');
+
+        foreach ($indexed as $key => $row) {
+            $this->assertSame($key, $row->id);
+        }
+    }
 }


### PR DESCRIPTION
Being able to index a collection by a key is often used for comparison
and manipulation of collections.
