### PR TITLE
Remove composer self-update call in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ matrix:
       env: 'COMPOSER_FLAGS="--prefer-stable --prefer-lowest"'
 
 before_script:
-  - travis_retry composer self-update
   - travis_retry composer require phpunit/phpunit phpbench/phpbench
   - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction --prefer-source
 


### PR DESCRIPTION
Travis VMs now do this by default. Removing it here reduces the build time by an average of 3-4 seconds.
