### PR TITLE
Fix HHVM test failures

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,9 @@
     "require": {
         "php": ">=5.5"
     },
+    "require-dev": {
+        "lstrojny/functional-php": "1.0.0|1.2.0"
+    },
     "suggest": {
         "phpunit/phpunit": "Install globally to run unit tests",
         "phpbench/phpbench": "Install globally to run benchmarks"


### PR DESCRIPTION
This change temporarily locks versions of the dependency causing HHVM builds to fail.

Refs lstrojny/functional-php#97
