### PR TITLE
Add array wrapper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,13 @@
 language: php
 
 php:
-  - 5.5
   - 5.6
   - 7.0
   - hhvm
 
 matrix:
   include:
-    - php: 5.5
+    - php: 5.6
       env: 'COMPOSER_FLAGS="--prefer-stable --prefer-lowest"'
 
 before_script:

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": ">=5.5"
+        "php": ">=5.6"
     },
     "suggest": {
         "phpunit/phpunit": "Install globally to run unit tests",

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,9 @@
         "phpbench/phpbench": "Install globally to run benchmarks"
     },
     "autoload": {
+        "classmap": [
+            "src/"
+        ],
         "files": [
             "src/array.php"
         ]

--- a/src/Chain.php
+++ b/src/Chain.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Equip;
+
+use function Equip\Arr\to_array;
+
+class Chain
+{
+    public static function from($source)
+    {
+        return new static(to_array($source));
+    }
+
+    /**
+     * @var array
+     */
+    private $source;
+
+    public function __construct(array $source)
+    {
+        $this->source = $source;
+    }
+
+    public function toArray()
+    {
+        return $this->source;
+    }
+
+    public function hasKey($needle)
+    {
+        return array_key_exists($needle, $this->source);
+    }
+
+    public function hasValue($needle)
+    {
+        return in_array($needle, $this->source);
+    }
+
+    public function reduce(callable $fn, $initial = null)
+    {
+        return array_reduce($this->source, $fn, $initial);
+    }
+
+    public function filter(callable $fn)
+    {
+        $copy = clone $this;
+        $copy->source = array_filter($this->source, $fn);
+
+        return $copy;
+    }
+
+    public function map(callable $fn)
+    {
+        $copy = clone $this;
+        $copy->source = array_map($fn, $this->source);
+
+        return $copy;
+    }
+
+    public function merge(array $values)
+    {
+        $copy = clone $this;
+        $copy->source = array_merge($this->source, $values);
+
+        return $copy;
+    }
+
+    public function intersect(array $values)
+    {
+        $copy = clone $this;
+        $copy->source = array_intersect($this->source, $values);
+
+        return $copy;
+    }
+
+    public function diff(array $values)
+    {
+        $copy = clone $this;
+        $copy->source = array_diff($this->source, $values);
+
+        return $copy;
+    }
+
+    public function unique()
+    {
+        $copy = clone $this;
+        $copy->source = array_unique($this->source);
+
+        return $copy;
+    }
+
+    public function values()
+    {
+        $copy = clone $this;
+        $copy->source = array_values($this->source);
+
+        return $copy;
+    }
+
+    public function keys()
+    {
+        $copy = clone $this;
+        $copy->source = array_keys($this->source);
+
+        return $copy;
+    }
+}

--- a/src/Chain.php
+++ b/src/Chain.php
@@ -6,6 +6,13 @@ use function Equip\Arr\to_array;
 
 class Chain
 {
+    /**
+     * Create a new chain from a source.
+     *
+     * @param array|Traversable $source
+     *
+     * @return static
+     */
     public static function from($source)
     {
         return new static(to_array($source));
@@ -16,26 +23,53 @@ class Chain
      */
     private $source;
 
+    /**
+     * @param array $source
+     */
     public function __construct(array $source)
     {
         $this->source = $source;
     }
 
+    /**
+     * Get the current source.
+     *
+     * @return array
+     */
     public function toArray()
     {
         return $this->source;
     }
 
+    /**
+     * Check if a key is defined in the source.
+     *
+     * @param mixed $needle
+     *
+     * @return boolean
+     */
     public function hasKey($needle)
     {
         return array_key_exists($needle, $this->source);
     }
 
+    /**
+     * Check if a value is defined in the source.
+     *
+     * @param mixed $needle
+     *
+     * @return boolean
+     */
     public function hasValue($needle)
     {
         return in_array($needle, $this->source);
     }
 
+    /**
+     * Get a copy with only values.
+     *
+     * @return static
+     */
     public function values()
     {
         $copy = clone $this;
@@ -44,6 +78,11 @@ class Chain
         return $copy;
     }
 
+    /**
+     * Get a copy with only keys.
+     *
+     * @return static
+     */
     public function keys()
     {
         $copy = clone $this;
@@ -52,6 +91,13 @@ class Chain
         return $copy;
     }
 
+    /**
+     * Get a copy merged with new values.
+     *
+     * @param array $values
+     *
+     * @return static
+     */
     public function merge(array $values)
     {
         $copy = clone $this;
@@ -60,6 +106,13 @@ class Chain
         return $copy;
     }
 
+    /**
+     * Get a copy intersected with new values.
+     *
+     * @param array $values
+     *
+     * @return static
+     */
     public function intersect(array $values)
     {
         $copy = clone $this;
@@ -68,6 +121,13 @@ class Chain
         return $copy;
     }
 
+    /**
+     * Get a copy diffed with other values.
+     *
+     * @param array $values
+     *
+     * @return static
+     */
     public function diff(array $values)
     {
         $copy = clone $this;
@@ -76,6 +136,11 @@ class Chain
         return $copy;
     }
 
+    /**
+     * Get a copy with only unique values.
+     *
+     * @return static
+     */
     public function unique()
     {
         $copy = clone $this;
@@ -84,11 +149,26 @@ class Chain
         return $copy;
     }
 
+    /**
+     * Reduce the array with a callback.
+     *
+     * @param callable $fn
+     * @param mixed $initial
+     *
+     * @return mixed
+     */
     public function reduce(callable $fn, $initial = null)
     {
         return array_reduce($this->source, $fn, $initial);
     }
 
+    /**
+     * Get a copy filtered with a callback.
+     *
+     * @param callable $fn
+     *
+     * @return static
+     */
     public function filter(callable $fn)
     {
         $copy = clone $this;
@@ -97,6 +177,13 @@ class Chain
         return $copy;
     }
 
+    /**
+     * Get a copy mapped with a callback.
+     *
+     * @param callable $fn
+     *
+     * @return static
+     */
     public function map(callable $fn)
     {
         $copy = clone $this;

--- a/src/Chain.php
+++ b/src/Chain.php
@@ -36,23 +36,18 @@ class Chain
         return in_array($needle, $this->source);
     }
 
-    public function reduce(callable $fn, $initial = null)
-    {
-        return array_reduce($this->source, $fn, $initial);
-    }
-
-    public function filter(callable $fn)
+    public function values()
     {
         $copy = clone $this;
-        $copy->source = array_filter($this->source, $fn);
+        $copy->source = array_values($this->source);
 
         return $copy;
     }
 
-    public function map(callable $fn)
+    public function keys()
     {
         $copy = clone $this;
-        $copy->source = array_map($fn, $this->source);
+        $copy->source = array_keys($this->source);
 
         return $copy;
     }
@@ -89,18 +84,23 @@ class Chain
         return $copy;
     }
 
-    public function values()
+    public function reduce(callable $fn, $initial = null)
+    {
+        return array_reduce($this->source, $fn, $initial);
+    }
+
+    public function filter(callable $fn)
     {
         $copy = clone $this;
-        $copy->source = array_values($this->source);
+        $copy->source = array_filter($this->source, $fn);
 
         return $copy;
     }
 
-    public function keys()
+    public function map(callable $fn)
     {
         $copy = clone $this;
-        $copy->source = array_keys($this->source);
+        $copy->source = array_map($fn, $this->source);
 
         return $copy;
     }

--- a/tests/ChainTest.php
+++ b/tests/ChainTest.php
@@ -6,27 +6,109 @@ use PHPUnit_Framework_TestCase as TestCase;
 
 class ChainTest extends TestCase
 {
-    public function testChain()
+    /**
+     * @var array
+     */
+    private $raw = [
+        'foo' => 'hello',
+        'bar' => 'world',
+        'baz' => '!',
+    ];
+
+    /**
+     * @var Chain
+     */
+    private $chain;
+
+    public function setUp()
     {
-        $arr = Chain::from([
-                'foo' => 'hello',
-                'bar' => 'world',
-                'baz' => '!',
-            ])
-            ->filter(function ($value) {
-                return ctype_alpha($value);
-            });
+        $this->chain = Chain::from($this->raw);
+    }
 
-        $this->assertTrue($arr->hasKey('foo'));
-        $this->assertFalse($arr->hasKey('baz'));
+    public function testToArray()
+    {
+        $this->assertSame($this->raw, $this->chain->toArray());
+    }
 
-        $this->assertTrue($arr->hasValue('hello'));
-        $this->assertFalse($arr->hasValue('pirate'));
+    public function testHasKey()
+    {
+        $this->assertTrue($this->chain->hasKey('foo'));
+        $this->assertFalse($this->chain->hasKey('fizz'));
+    }
 
-        $arr = $arr->keys();
+    public function testValue()
+    {
+        $this->assertTrue($this->chain->hasValue('hello'));
+        $this->assertFalse($this->chain->hasValue('pirates'));
+    }
 
-        $this->assertFalse($arr->hasKey('foo'));
-        $this->assertTrue($arr->hasValue('foo'));
+    public function testKeys()
+    {
+        $this->markTestIncomplete();
+    }
 
+    public function testValues()
+    {
+        $this->markTestIncomplete();
+    }
+
+    public function testMerge()
+    {
+        $this->markTestIncomplete();
+    }
+
+    public function testIntersect()
+    {
+        $this->markTestIncomplete();
+    }
+
+    public function testDiff()
+    {
+        $this->markTestIncomplete();
+    }
+
+    public function testUnique()
+    {
+        $this->markTestIncomplete();
+    }
+
+    public function testReduce()
+    {
+        $want = 'world';
+        $value = $this->chain->reduce(function ($carry, $item) use ($want) {
+            if ($item === $want) {
+                return $item;
+            }
+            return $carry;
+        });
+
+        $this->assertSame($want, $value);
+    }
+
+    public function testFilter()
+    {
+        $arr = $this->chain
+            ->filter(function ($item) {
+                return ctype_alpha($item);
+            })
+            ->toArray();
+
+        $this->assertArrayHasKey('foo', $arr);
+        $this->assertArrayHasKey('bar', $arr);
+
+        $this->assertArrayNotHasKey('baz', $arr);
+    }
+
+    public function testMap()
+    {
+        $arr = $this->chain
+            ->map(function ($item) {
+                return strrev($item);
+            })
+            ->toArray();
+
+        $this->assertSame('olleh', $arr['foo']);
+        $this->assertSame('dlrow', $arr['bar']);
+        $this->assertSame('!', $arr['baz']);
     }
 }

--- a/tests/ChainTest.php
+++ b/tests/ChainTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Equip;
+
+use PHPUnit_Framework_TestCase as TestCase;
+
+class ChainTest extends TestCase
+{
+    public function testChain()
+    {
+        $arr = Chain::from([
+                'foo' => 'hello',
+                'bar' => 'world',
+                'baz' => '!',
+            ])
+            ->filter(function ($value) {
+                return ctype_alpha($value);
+            });
+
+        $this->assertTrue($arr->hasKey('foo'));
+        $this->assertFalse($arr->hasKey('baz'));
+
+        $this->assertTrue($arr->hasValue('hello'));
+        $this->assertFalse($arr->hasValue('pirate'));
+
+        $arr = $arr->keys();
+
+        $this->assertFalse($arr->hasKey('foo'));
+        $this->assertTrue($arr->hasValue('foo'));
+
+    }
+}

--- a/tests/ChainTest.php
+++ b/tests/ChainTest.php
@@ -44,32 +44,64 @@ class ChainTest extends TestCase
 
     public function testKeys()
     {
-        $this->markTestIncomplete();
+        $arr = $this->chain->keys()->toArray();
+
+        $this->assertSame(array_keys($this->raw), $arr);
     }
 
     public function testValues()
     {
-        $this->markTestIncomplete();
+        $arr = $this->chain->values()->toArray();
+
+        $this->assertSame(array_values($this->raw), $arr);
     }
 
     public function testMerge()
     {
-        $this->markTestIncomplete();
+        $values = [
+            'fizz' => 'test',
+            'buzz' => 'friends',
+        ];
+        $arr = $this->chain
+            ->merge($values)
+            ->toArray();
+
+        $this->assertSame(array_merge($this->raw, $values), $arr);
     }
 
     public function testIntersect()
     {
-        $this->markTestIncomplete();
+        $values = [
+            'fizz' => 'test',
+            'buzz' => 'world',
+        ];
+        $arr = $this->chain
+            ->intersect($values)
+            ->toArray();
+
+        $this->assertSame(array_intersect($this->raw, $values), $arr);
     }
 
     public function testDiff()
     {
-        $this->markTestIncomplete();
+        $values = [
+            'fizz' => 'hello',
+            'buzz' => 'test',
+        ];
+        $arr = $this->chain
+            ->diff($values)
+            ->toArray();
+
+        $this->assertSame(array_diff($this->raw, $values), $arr);
     }
 
     public function testUnique()
     {
-        $this->markTestIncomplete();
+        $arr = $this->chain
+            ->unique()
+            ->toArray();
+
+        $this->assertSame(array_unique($this->raw), $arr);
     }
 
     public function testReduce()


### PR DESCRIPTION
Provide a consistent, fluent interface for calling array functions.

I want something like Underscore.php or HArray that is just a straight forward wrapper around array functions that take the guessing out of order of operations. For example:

``` php
$foo = array_filter($arr, $fn);
// vs ...
$foo = array_map($fn, $arr);
```

Can be made consistent as:

``` php
$foo = Chain::from($arr)->filter($fn)->toArray();
$foo = Chain::from($arr)->map($fn)->toArray();
```
