### PR TITLE
Add column() function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.3.0 - 2016-08-25
+### Added
+
+- Add `column()` array helper
+
 ## 1.2.0 - 2016-07-01
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -37,3 +37,5 @@ Import any function with `use function Equip\Arr\func;`.
 `tail($list)` get the last value from a list.
 
 `index_by($source, $key)` index a collection by a key.
+
+`column($source, $column)` get a list of values from a collection.

--- a/src/array.php
+++ b/src/array.php
@@ -122,6 +122,39 @@ function expect($source, $keys, $default = null)
 }
 
 /**
+ * Get a list from an array.
+ *
+ * Similar to array_column(), with the following exceptions:
+ *
+ * 1. Only returns a list from a single column.
+ * 2. Works with iterator collections.
+ * 3. Works with object rows.
+ *
+ * @param array|Traversable $source
+ * @param string $column
+ *
+ * @return array
+ */
+function column($source, $column = null)
+{
+    $values = [];
+
+    foreach ($source as $row) {
+        if (is_object($row)) {
+            if (isset($row->$column)) {
+                $values[] = $row->$column;
+            }
+        } else {
+            if (isset($row[$column])) {
+                $values[] = $row[$column];
+            }
+        }
+    }
+
+    return $values;
+}
+
+/**
  * Take the first value from an array.
  *
  * @param array $list

--- a/tests/ArrayTest.php
+++ b/tests/ArrayTest.php
@@ -238,4 +238,48 @@ class ArrayTest extends TestCase
         $new_source = array_replace_keys($source, $keys_to_replace);
         $this->assertSame($source, $new_source);
     }
+
+    public function dataColumn()
+    {
+        $collection = [
+            [
+                'id' => 1,
+                'name' => 'joe',
+            ],
+            [
+                'id' => 2,
+                'name' => 'joe',
+            ],
+            [
+                'id' => 3,
+                'name' => 'sue',
+            ],
+            [
+                'id' => 4,
+                'name' => null,
+            ],
+        ];
+
+        return [
+            'array' => [
+                $collection,
+            ],
+            'object' => [
+                // simple recursive object conversion
+                json_decode(json_encode($collection), false),
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider dataColumn
+     */
+    public function testColumn($collection)
+    {
+        $ids = column($collection, 'id');
+        $this->assertSame([1, 2, 3, 4], $ids);
+
+        $names = column($collection, 'name');
+        $this->assertSame(['joe', 'joe', 'sue'], $names);
+    }
 }


### PR DESCRIPTION
In HHVM and PHP <7.0, `array_column` does not work with objects.
Cover the most basic use case for simplicity.
