### PR TITLE
Add `typed()` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.5.0 - 2016-08-29
+### Added
+
+- Add `typed()` array helper
+
 ## 1.4.0 - 2016-08-25
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -39,3 +39,5 @@ Import any function with `use function Equip\Arr\func;`.
 `index_by($source, $key)` index a collection by a key.
 
 `column($source, $column)` get a list of values from a collection.
+
+`typed($source, $types)` type cast defined values in an array.

--- a/src/array.php
+++ b/src/array.php
@@ -211,7 +211,7 @@ function index_by($source, $key)
  *
  * @param array|Traversable $source
  * @param array $keys_to_replace key/value pairs [search => replace]
- * 
+ *
  * @return array
  */
 function array_replace_keys($source, $keys_to_replace)
@@ -225,4 +225,28 @@ function array_replace_keys($source, $keys_to_replace)
     $replaced_keys = array_replace(array_combine($keys, $keys), $keys_to_replace);
 
     return array_combine($replaced_keys, $source);
+}
+
+/**
+ * Type cast some values in an array.
+ *
+ * Only defined values will be typed.
+ *
+ * @param array|Traversable $source
+ * @param array $types
+ *
+ * @return array
+ */
+function typed($source, array $types)
+{
+    $source = to_array($source);
+    $values = array_intersect_key($source, $types);
+
+    foreach ($values as $key => $value) {
+        if ($value !== null) {
+            settype($values[$key], $types[$key]);
+        }
+    }
+
+    return array_replace($source, $values);
 }

--- a/tests/ArrayTypedTest.php
+++ b/tests/ArrayTypedTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Equip\Arr;
+
+use ArrayObject;
+use PHPUnit_Framework_TestCase as TestCase;
+
+class ArrayTypedTest extends TestCase
+{
+    public function testTyped()
+    {
+        $values = [
+            'user_id' => '5',
+            'account_id' => 1,
+            'created_by' => null,
+            'is_active' => 1,
+        ];
+
+        $output = typed($values, [
+            'user_id' => 'int',
+            'account_id' => 'int',
+            'created_by' => 'int',
+            'is_active' => 'bool',
+            'email' => 'string',
+        ]);
+
+        $this->assertSame($output, [
+            'user_id' => 5,
+            'account_id' => 1,
+            'created_by' => null,
+            'is_active' => true,
+        ]);
+    }
+}


### PR DESCRIPTION
Often it is useful to type cast some values in an array to ensure that
comparisons work as expected.
