### PR TITLE
Test against the current hhvm version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,22 @@
+# Forces faster Travis-CI Container Infrastructure
+sudo: false
 language: php
 
 php:
   - 5.5
   - 5.6
   - 7.0
-  - hhvm
+  - 7.1
 
 matrix:
+  fast_finish: true
   include:
     - php: 5.5
       env: 'COMPOSER_FLAGS="--prefer-stable --prefer-lowest"'
+    - php: hhvm
+      sudo: true
+      dist: trusty
+      group: edge # Until the next stable group update after 2016-12-01
 
 before_script:
   - travis_retry composer require phpunit/phpunit phpbench/phpbench


### PR DESCRIPTION
You are currently testing on an old EOL version of HHVM 3.6.6 (a limitation of precise on Travis)

This PR provides the current HHVM version (3.15.3 as of this PR) and will track with each release (i.e. will be 3.16 when 3.16 is released).

If testing against HHVM LST versions is desired follow this guide. https://docs.travis-ci.com/user/languages/php#HHVM-versions

Should be able to change to container based Trusty after Q1-17 https://blog.travis-ci.com/2016-11-08-trusty-container-public-beta/

Additionally adds php 7.1 and switches most tests to the faster Travis-CI Container Infrastructure